### PR TITLE
Update file size and token count checks to log warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## [0.2.5] - 2023-11-25
+- [Modification] Updated File Size and Token Count Checks
+  - Modified the `combine_files` method in `gptizer.py` to log a warning instead of raising an error when the total size of the combined content exceeds the `MAX_FILE_SIZE_BYTES_LIMIT` or `MAX_TOKEN_COUNT_LIMIT` defined in `settings.py`.
+
+
 ## [0.2.4] - 2023-11-16
 - [Feature] Custom Output File Naming
   - Output files now include the name of the processed file or directory, enhancing traceability and identification.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - Support for various encodings when reading files.
 - Customizable output file naming based on the input file or directory name.
 - Report generation including all processed files.
+- Enhanced limit checks for file size and token count, with warnings logged instead of errors raised when limits are exceeded.
 
 ## Installation
 To install `gptize`, simply use pip:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('CHANGELOG.md', 'r', encoding='utf-8') as cl:
 
 setup(
     name='gptize',
-    version='0.2.4',
+    version='0.2.5',
     url='https://github.com/svetlovtech/gptize',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
- Modified `combine_files` in `gptizer.py` to log warnings when file size or token count limits are exceeded.
- Updated `CHANGELOG.md` with new version information and details of changes.
- Revised `README.md` to include updated feature information reflecting the new warning mechanism.